### PR TITLE
config: Add SQL alias support

### DIFF
--- a/.elfquery.toml
+++ b/.elfquery.toml
@@ -1,0 +1,12 @@
+[sqlaliases]
+sections = "SELECT Name, printf('0x%X', Address) AS Address, Size FROM sections"
+symbols = "SELECT * FROM symbols ORDER BY ID ASC"
+symbols_sz = "SELECT * FROM symbols ORDER BY Size ASC"
+symbols_code = "SELECT * FROM symbols WHERE Type = 'code' ORDER BY Name ASC"
+symbols_data = "SELECT * FROM symbols WHERE Type = 'data' ORDER BY Name ASC"
+symbols_code_sz = "SELECT * FROM symbols WHERE Type = 'code' ORDER BY Size ASC"
+symbols_data_sz = "SELECT * FROM symbols WHERE Type = 'data' ORDER BY Size ASC"
+bss = "SELECT Name, Size FROM symbols WHERE Section = 'bss' ORDER BY Name"
+bss_sz = "SELECT Name, Size FROM symbols WHERE Section = 'bss' ORDER BY Size"
+bss10 = "SELECT Name, Size FROM symbols WHERE Section = 'bss' ORDER BY Size DESC LIMIT 10"
+weak = "SELECT * FROM symbols WHERE Binding LIKE 'weak' ORDER BY Name"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,29 @@ ToDo
 ### SQL Queries (`sql`)
 
 Once parsed, the ELF file can be queried in the REPL, or by sending a SQL query
-with the `-q` parameter:
+with the `-q` parameter, or by sending a query alias matching a sqlaliases
+record in `.elfquery.toml`.
+
+> run `elfquery sql samples/lpc55s69_zephyr.elf -a help` to list available
+  aliases):
+
+```bash
+$ elfquery sql samples/lpc55s69_zephyr.elf -a bss10
++--------------------------+------+
+| NAME                     | SIZE |
++--------------------------+------+
+| z_main_thread            | 128  |
+| z_idle_threads           | 128  |
+| gpio_mcux_lpc_port0_data | 80   |
+| gpio_mcux_lpc_port1_data | 80   |
+| _kernel                  | 48   |
+| s_pintCallback           | 32   |
+| dyn_reg_info             | 20   |
+| s_secpintCallback        | 8    |
+| curr_tick                | 8    |
+| mcux_flexcomm_0_data     | 8    |
++--------------------------+------+
+```
 
 ```bash
 $ elfquery sql samples/lpc55s69_zephyr.elf -q \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ func initConfig() {
 		}
 
 		// Search config in home directory with name ".elfquery" (without extension).
+		viper.AddConfigPath(".")
 		viper.AddConfigPath(home)
 		viper.SetConfigName(".elfquery")
 	}
@@ -64,6 +65,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+		// fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
 }


### PR DESCRIPTION
Adds support for SQL query aliases to be defined in the
.elfquery.toml file, and executed via the new `-a` alias flag.

Signed-off-by: Kevin Townsend <kevin@ktownsend.com>